### PR TITLE
fix: after slicing name trim to remove whitespace

### DIFF
--- a/scripts/pull_from_dune.py
+++ b/scripts/pull_from_dune.py
@@ -43,7 +43,7 @@ for id in query_ids:
                 file.write(f'-- part of a query repo\n-- query name: {query.base.name}\n-- query link: https://dune.com/queries/{query.base.query_id}\n\n\n{query.sql}')
     else:
         # Create new file and directories if they don't exist
-        new_file = f'{query.base.name.replace(" ", "_").lower()[:30]}___{query.base.query_id}.sql'
+        new_file = f'{query.base.name.lower()[:30].strip().replace(" ", "_")}___{query.base.query_id}.sql'
         file_path = os.path.join(os.path.dirname(__file__), '..', 'queries', new_file)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         


### PR DESCRIPTION
| Original | Updated | Change | Reasoning |
|---|---|---|---|
| `scripts/pull_from_dune.py` | n/a | strip white space after slicing name | prevents extra underscore between query name and query id |

**Provide any other context or screenshots that explain or justify the changes above:**

If the sliced name ends in white space replacing whitespace with underscores will add an extra underscore at the end of the file which can cause issues when prasing for the query id

---

**Note to Contributor:**

Make sure your PR edits the original `query_id.sql` file with the new query text. If you are proposing adding a new query completely, make sure to add it to `queries.yml` and as a file in `/queries` as well.

Thanks for contributing! 🙏